### PR TITLE
update to 0.9.4 with a little fix of info.chenyufei.cow.plist

### DIFF
--- a/cow.rb
+++ b/cow.rb
@@ -39,10 +39,7 @@ class Cow < Formula
             <string>#{opt_prefix}/bin/cow</string>
         </array>
         <key>KeepAlive</key>
-        <dict>
-          <key>NetworkState</key>
-          <true/>
-        </dict>
+        <true/>
       </dict>
     </plist>
     EOS


### PR DESCRIPTION
Since the binary of `0.9.1` moved to a [new place](http://dl.chenyufei.info/cow/0.9.1/cow-mac64-0.9.1.gz), this tap won't work any more.

However after version bumping, I found an error in `info.chenyufei.cow.plist` that prevents launchd from launching `cow`, this fix works for me on `OS X 10.10`.
